### PR TITLE
NotionのS3署名付きURLは1時間で期限切れになるため、30分ごとに新しいURLを取得するように変更

### DIFF
--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -4,6 +4,10 @@ import BlogList from "../components/BlogList/BlogList";
 import { getBlogPosts } from "../../app/lib/notion";
 import Link from "next/link";
 
+// NotionのS3署名付きURLは1時間で期限切れになるため、
+// 30分ごとに再検証して新しいURLを取得する
+export const revalidate = 1800;
+
 const Blogs = async () => {
   const posts = await getBlogPosts();
 

--- a/src/app/components/BlogCard/BlogCard.tsx
+++ b/src/app/components/BlogCard/BlogCard.tsx
@@ -69,6 +69,7 @@ export default function BlogCard({ post }: BlogCardProps) {
               fill
               className="object-cover"
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              unoptimized
             />
           </div>
         ) : (
@@ -106,6 +107,7 @@ export default function BlogCard({ post }: BlogCardProps) {
           width={32}
           height={32}
           className="rounded-full mr-2 border border-gray-300 dark:border-gray-600"
+          unoptimized
         />
       )}
       <span className="text-gray-700 dark:text-gray-300 text-sm">


### PR DESCRIPTION
Add revalidation for Notion S3 signed URLs and optimize BlogCard images

修正内容
1. BlogCard.tsx - unoptimized プロパティを追加
サムネイル画像と著者アイコンの Image コンポーネントに unoptimized を追加
これにより、Next.jsの画像最適化をバイパスし、Notionの署名付きURLを直接使用
2. page.tsx - revalidate を追加
export const revalidate = 1800; （30分）を追加
NotionのS3署名付きURLは1時間で期限切れになるため、30分ごとに新しいURLを取得