### PR TITLE
Projects Page, Member Pageについて画像が表示されない問題を解消

### DIFF
--- a/src/app/components/ProjectCard.tsx
+++ b/src/app/components/ProjectCard.tsx
@@ -25,6 +25,7 @@ const ProjectCard: React.FC<ProjectProps> = ({ logo, name, summary, pm, href }) 
               alt="Project Logo"
               fill
               className={styles.logoImage}
+              unoptimized
             />
           ) : (
             <span className={styles.cardTitleFallback}>{name}</span>
@@ -43,6 +44,7 @@ const ProjectCard: React.FC<ProjectProps> = ({ logo, name, summary, pm, href }) 
               width={40} // サイズ指定
               height={40}
               className={styles.pmIcon}
+              unoptimized
             />
           )}
           <span className={styles.pmName}>{pm.name}</span>

--- a/src/app/components/TeamCard.tsx
+++ b/src/app/components/TeamCard.tsx
@@ -29,7 +29,7 @@ const TeamCard: React.FC<TeamProps> = ({ name, description, technologies, pm, hr
         <div className={`${styles.cardSection} ${styles.pmInline}`}>
           <h3 className={styles.sectionTitle}>PM：</h3>
           <div className={styles.pmInfo}>
-            <Image src={pm.icon} alt={pm.name} width={30} height={30} className={styles.pmIcon} />
+            <Image src={pm.icon} alt={pm.name} width={30} height={30} className={styles.pmIcon} unoptimized />
             <span className={styles.pmName}>{pm.name}</span>
           </div>
         </div>

--- a/src/app/members/[id]/MemberPageClient.tsx
+++ b/src/app/members/[id]/MemberPageClient.tsx
@@ -33,6 +33,7 @@ export default function MemberPageClient({ member, posts }: MemberPageClientProp
               width={160}
               height={160}
               className="member-icon"
+              unoptimized
             />
           )}
           <h1 className="member-name">{member.nickname}</h1>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -3,7 +3,9 @@ import { getAllMembers } from '../lib/member';
 import Link from 'next/link';
 import styles from './members.module.css';
 
-export const revalidate = 60;
+// NotionのS3署名付きURLは1時間で期限切れになるため、
+// 30分ごとに再検証して新しいURLを取得する
+export const revalidate = 1800;
 
 export default async function Members() {
   const members = await getAllMembers();
@@ -34,6 +36,7 @@ export default async function Members() {
                     width={200}
                     height={200}
                     className="rounded-full object-cover mx-auto mb-4 aspect-square w-40 h-40"
+                    unoptimized
                   />
                 )}
               </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -4,6 +4,10 @@ import { getAllProjects } from "../lib/project";
 import Breadcrumb from "../components/Breadcrumb"; 
 import styles from "./ProjectsPage.module.css";
 
+// NotionのS3署名付きURLは1時間で期限切れになるため、
+// 30分ごとに再検証して新しいURLを取得する
+export const revalidate = 1800;
+
 export default async function ProjectsPage() {
   const projects = await getAllProjects();
 


### PR DESCRIPTION
Projects Page, Member Pageについても、NotionのS3署名付きURLは1時間で期限切れになるため、30分ごとに新しいURLを取得するように変更
(Projects Page, Member Page)

Add unoptimized attribute to images in ProjectCard, TeamCard, and MemberPageClient components; update revalidation time in Members and Projects pages