### PR TITLE
静的画像のnext/image化による画像最適化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'prod-files-secure.s3.us-west-2.amazonaws.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'blog.nutmeg.cloud',
+      },
     ],
   },
 };

--- a/src/app/components/NavigationButton.css
+++ b/src/app/components/NavigationButton.css
@@ -31,6 +31,11 @@
   height: 40px;
 }
 
+.arrow-wrapper > span {
+  position: absolute !important;
+  inset: 0;
+}
+
 .arrow-wrapper img {
   position: absolute;
   top: 0;

--- a/src/app/components/NavigationButton.tsx
+++ b/src/app/components/NavigationButton.tsx
@@ -1,5 +1,6 @@
 import "./NavigationButton.css";
 import Link from "next/link";
+import Image from "next/image";
 
 interface NavigationButtonProps {
   text: string;
@@ -13,15 +14,47 @@ const NavigationButton = ({ text, href, onClick, arrowLeft = false }: Navigation
     <>
       {arrowLeft && (
         <div className="arrow-wrapper left">
-          <img className="arrow-normal" src="/ArrowYellowOrange.svg" alt="Arrow" width={40} height={40} />
-          <img className="arrow-hover" src="/ArrowWhite.svg" alt="Arrow" width={40} height={40} />
+          <Image
+            className="arrow-normal"
+            src="/ArrowYellowOrange.svg"
+            alt="Arrow"
+            width={40}
+            height={40}
+            loading="lazy"
+            sizes="40px"
+          />
+          <Image
+            className="arrow-hover"
+            src="/ArrowWhite.svg"
+            alt="Arrow"
+            width={40}
+            height={40}
+            loading="lazy"
+            sizes="40px"
+          />
         </div>
       )}
       <p>{text}</p>
       {!arrowLeft && (
         <div className="arrow-wrapper">
-          <img className="arrow-normal" src="/ArrowYellowOrange.svg" alt="Arrow" width={40} height={40} />
-          <img className="arrow-hover" src="/ArrowWhite.svg" alt="Arrow" width={40} height={40} />
+          <Image
+            className="arrow-normal"
+            src="/ArrowYellowOrange.svg"
+            alt="Arrow"
+            width={40}
+            height={40}
+            loading="lazy"
+            sizes="40px"
+          />
+          <Image
+            className="arrow-hover"
+            src="/ArrowWhite.svg"
+            alt="Arrow"
+            width={40}
+            height={40}
+            loading="lazy"
+            sizes="40px"
+          />
         </div>
       )}
     </>

--- a/src/app/components/OldSitePreview.tsx
+++ b/src/app/components/OldSitePreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import styles from "./OldSitePreview.module.css";
 import { SITE_URLS } from "@/app/config";
 
@@ -28,12 +29,15 @@ export default function OldSitePreview() {
           rel="noopener noreferrer"
           className={styles.card}
         >
-        <img
-        src={ogImage}
-        alt="旧サイトのプレビュー"
-        className="old-site-preview"
-        // styleつけてもいい
-        />
+          <Image
+            src={ogImage}
+            alt="旧サイトのプレビュー"
+            className={styles.thumbnail}
+            width={1200}
+            height={630}
+            loading="lazy"
+            sizes="(max-width: 768px) 90vw, 70vw"
+          />
 
         </a>
       ) : (

--- a/src/app/components/carousel.tsx
+++ b/src/app/components/carousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Image from "next/image";
 import styles from "./carousel.module.css";
 
 const images = [
@@ -18,7 +19,16 @@ export default function Carousel() {
       <div className={styles.sliderTrack}>
         {/* 画像を2回繰り返すことで途切れない無限ループにする */}
         {[...images, ...images].map((src, idx) => (
-          <img key={idx} src={src} alt="活動写真" className={styles.pics} />
+          <Image
+            key={idx}
+            src={src}
+            alt="活動写真"
+            className={styles.pics}
+            width={640}
+            height={640}
+            loading="lazy"
+            sizes="(max-width: 768px) 220px, 400px"
+          />
         ))}
       </div>
     </div>

--- a/src/app/components/topbar.module.css
+++ b/src/app/components/topbar.module.css
@@ -14,6 +14,9 @@
   transition: background-color 0.3s ease, color 0.3s ease, border-bottom 0.3s ease;
   font-size: 20px;
 }
+.brandIcon {
+  display: block;
+}
 .topbarRight {
   display: flex;
   width: 282px;
@@ -297,10 +300,9 @@ line-height: normal;
   }
 
   /* トップバーのロゴを白ロゴに差し替え */
-  .topbar img[src*="NUTMEG_Icon.svg"] {
+  .brandIcon {
     content: url('/topbar_icons/NUTMEG_Icon_White.svg');
   }
 
   /* ハンバーガーメニュー内のロゴは既に白なので不要 */
 }
-

--- a/src/app/components/topbar.tsx
+++ b/src/app/components/topbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import styles from "./topbar.module.css";
 import { usePathname } from "next/navigation";
 import { useEffect } from "react";
+import Image from "next/image";
 const TopBar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
@@ -26,20 +27,28 @@ const TopBar = () => {
           style={{ display: menuOpen ? "none" : "flex" }}
         >
         <Link href="/">
-            <img
+            <Image
               src="/topbar_icons/NUTMEG_Icon.svg"
               // src="/topbar_icons/NUTMEG_logo.svg"
               alt="NUTMEG"
-              className={styles.icon}
+              className={`${styles.icon} ${styles.brandIcon}`}
+              width={149}
+              height={62}
+              priority
+              sizes="(max-width: 768px) 130px, 149px"
             />
         </Link>
 
         <div className={styles.topbarRight}>
           <Link href="/contact">
-            <img
+            <Image
               src="/topbar_icons/ContactButton.svg"
               alt="Contact"
               className={styles.icon}
+              width={176}
+              height={48}
+              priority
+              sizes="(max-width: 768px) 140px, 176px"
             />
           </Link>
 
@@ -61,10 +70,14 @@ const TopBar = () => {
       >
         <div className={styles.hamburgerMenuTop}>
           <Link href="/">
-            <img
+            <Image
               src="/topbar_icons/NUTMEG_Icon_White.svg"
               alt="NUTMEG"
               className={styles.icon}
+              width={149}
+              height={62}
+              priority
+              sizes="(max-width: 768px) 130px, 149px"
             />
           </Link>
           <div className={styles.hamburgerButton} onClick={toggleMenu}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 // "use client";
 // import React, { useEffect, useState } from "react";
 import { Suspense } from "react";
+import Image from "next/image";
 import NavigationButton from "./components/NavigationButton";
 import styles from "./Home.module.css"; // CSSファイルのインポート
 import FadeInSection from "./components/FadeInSection/FadeInSection";
@@ -16,15 +17,23 @@ export default async function Home() {
   return (
     <>
       <div className={styles.HeroImage}>
-        <img
+        <Image
           src="/home/HeroImage_Mission.svg"
           alt="HeroImage"
           className={styles.HeroImageimageMisson}
+          width={437}
+          height={256}
+          priority
+          sizes="(max-width: 768px) 40vw, 25vw"
         />
-        <img
+        <Image
           src="/home/HeroImage_BackImage.png"
           alt="HeroImage"
           className={styles.HeroImageimage}
+          width={5232}
+          height={2496}
+          priority
+          sizes="100vw"
         />
       </div>
 
@@ -59,18 +68,24 @@ export default async function Home() {
       <FadeInSection>
         <div className={styles.projects}>
           <div className={`${styles.whiteBox} ${styles.projectsWhiteBox}`}>
-            <img
+            <Image
               src="/home/TitleProjects.svg"
               className={styles.titleProjects}
               alt="Projects"
+              width={251}
+              height={61}
+              loading="lazy"
+              sizes="(max-width: 768px) 180px, 251px"
             />
             {/* <h1 className={styles.Sectiontitle}>Projects</h1> */}
             <div className={styles.projectsBox}>
-              <img
+              <Image
                 src="/home/Picture_Projects.svg"
                 alt="写真"
                 width={440}
                 height={320}
+                loading="lazy"
+                sizes="(max-width: 768px) 90vw, 440px"
               />
               <div>
                 <p>
@@ -88,19 +103,23 @@ export default async function Home() {
               </div>
             </div>
           </div>
-          <img
+          <Image
             src="/decoration.svg"
             alt="decoration"
-            width={154.96}
-            height={138.2}
+            width={155}
+            height={139}
             className={styles.decoration1}
+            loading="lazy"
+            sizes="(max-width: 768px) 0px, 155px"
           />
-          <img
+          <Image
             src="/decoration2.svg"
             alt="decoration"
-            width={170.9}
-            height={193.2}
+            width={171}
+            height={194}
             className={styles.decoration2}
+            loading="lazy"
+            sizes="(max-width: 768px) 0px, 171px"
           />
         </div>
       </FadeInSection>
@@ -115,11 +134,15 @@ export default async function Home() {
             /> */}
             <div className={styles.flexBox}>
               {/* <h1 className={styles.BlogTitle}>Blog</h1> */}
-            <img
-              src="/home/TitleBlog.svg"
-              className={styles.titleBlogs}
-              alt="Blog"
-            />
+              <Image
+                src="/home/TitleBlog.svg"
+                className={styles.titleBlogs}
+                alt="Blog"
+                width={134}
+                height={61}
+                sizes="(max-width: 768px) 180px, 134px"
+                loading="lazy"
+              />
             {/* <h1 className={styles.Sectiontitle}>Blog</h1> */}
 
 


### PR DESCRIPTION
- Notion APIレスポンスをnext/cacheで5分キャッシュするようにし、getBlogPosts/getNotionPageが繰り返し呼ばれてもAPI負荷が下がるようにしました（src/app/lib/notion.ts）。
- メインページの静的画像をnext/imageに置き換え、sizes指定と優先度設定・遅延読み込みを適用しました（src/app/page.tsx）
- カルーセル/旧サイトプレビュー/ナビゲーションボタン/トップバーの画像をnext/image化し、非表示時はlazy、ダークモード用ブランドアイコンの差し替えクラスを追加しました（src/app/components/carousel.tsx, OldSitePreview.tsx, NavigationButton.tsx, topbar.tsx, topbar.module.css, NavigationButton.css）。
- OGP画像最適化のためblog.nutmeg.cloudを画像ドメインに許可しました（next.config.ts）。

Refactor components to use Next.js Image for optimized loading and add new S3 hostname in configuration