### PR TITLE
旧サイトプレビューの修正

### DIFF
--- a/src/app/components/OldSitePreview.tsx
+++ b/src/app/components/OldSitePreview.tsx
@@ -1,48 +1,35 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Image from "next/image";
 import styles from "./OldSitePreview.module.css";
 import { SITE_URLS } from "@/app/config";
 
 export default function OldSitePreview() {
-  const [ogImage, setOgImage] = useState<string | null>(null);
-
-    useEffect(() => {
-    fetch(`/api/ogp?url=${encodeURIComponent(SITE_URLS.oldSite)}`)
-        .then(res => res.json())
-        .then(data => setOgImage(data.ogImage));
-    }, []);
-
   return (
     <div className={styles.container}>
       
       <h2 className={styles.title}>
         <div>2025年12月より、NUTMEGサイトを一新いたしました。</div>
         <div>旧サイトはこちらからご覧いただけます。</div>
-        </h2>
+      </h2>
 
-      {ogImage ? (
-        <a
-            href={SITE_URLS.oldSite}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.card}
-        >
-          <Image
-            src={ogImage}
-            alt="旧サイトのプレビュー"
-            className={styles.thumbnail}
-            width={1200}
-            height={630}
-            loading="lazy"
-            sizes="(max-width: 768px) 90vw, 70vw"
-          />
-
-        </a>
-      ) : (
-        <p>プレビューを読み込み中...</p>
-      )}
+      <a
+        href={SITE_URLS.oldSite}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.card}
+      >
+        <Image
+          src={SITE_URLS.oldSiteOgp}
+          alt="旧サイトのプレビュー"
+          className={styles.thumbnail}
+          width={1200}
+          height={630}
+          loading="lazy"
+          sizes="(max-width: 768px) 90vw, 70vw"
+          unoptimized
+        />
+      </a>
     </div>
   );
 }

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,3 +1,4 @@
 export const SITE_URLS = {
   oldSite: "https://archive-blog.nutmeg.cloud/",
+  oldSiteOgp: "https://archive-blog.nutmeg.cloud/images/OGP.png",
 };


### PR DESCRIPTION
問題: API経由でOGP画像を取得していたが、Edge Runtimeで動作しなかった

修正:
API呼び出しを削除
OGP画像URLをconfig.tsで一元管理
直接画像を表示するシンプルな実装に変更