### PR TITLE
メンバープロフィールページで、そのメンバーの投稿記事が表示されない問題を修正

### DIFF
--- a/src/app/members/[id]/page.tsx
+++ b/src/app/members/[id]/page.tsx
@@ -1,13 +1,12 @@
 // src/app/members/[id]/page.tsx
 import MemberPageClient from './MemberPageClient';
-import { getMemberProfile, getAllMembers } from '@/app/lib/member';
+import { getMemberProfile } from '@/app/lib/member';
 import { getBlogPostsByAuthor } from '@/app/lib/notion';
 import { BlogPost } from '@/app/types/blog';
 
-export async function generateStaticParams() {
-  const members = await getAllMembers();
-  return members.map(member => ({ id: member.id }));
-}
+// Cloudflare PagesではISRが非対応のため、動的レンダリングを使用
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
 
 interface MemberPageProps {
   params: Promise<{ id: string }>;


### PR DESCRIPTION
src/app/members/[id]/page.tsx に対して以下の変更を行いました：
- generateStaticParams 関数を削除 - ビルド時の静的生成を無効化
- getAllMembers のインポートを削除 - 不要になったため
- export const dynamic = 'force-dynamic' を追加 - 毎回リクエスト時に動的にデータを取得するように変更 export const
- runtime = 'edge' を追加 - Cloudflare Pages の Edge Runtime に対応

変更理由
Cloudflare Pages では ISR（Incremental Static Regeneration）がサポートされていないため、generateStaticParams による静的生成では投稿一覧がビルド時のデータで固定されてしまう。動的レンダリングに変更することで、ページアクセス時に最新の投稿データを取得できる