### PR TITLE
Notion本文データを描画前に正規化するよう修正

### DIFF
--- a/src/app/components/NotionPage/notionPage.tsx
+++ b/src/app/components/NotionPage/notionPage.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import { ExtendedRecordMap } from 'notion-types';
 import { Code } from 'react-notion-x/build/third-party/code';
 import { Equation } from 'react-notion-x/build/third-party/equation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import 'react-notion-x/src/styles.css';
 import 'prismjs/themes/prism-tomorrow.css';
 import 'katex/dist/katex.min.css';
@@ -18,8 +18,57 @@ interface NotionPageProps {
   recordMap: ExtendedRecordMap;
 }
 
+type RecordMapTable = Record<string, unknown>;
+
+const RECORD_MAP_TABLES = [
+  'block',
+  'collection',
+  'collection_view',
+  'collection_query',
+  'notion_user',
+  'space',
+] as const;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeRecordMapEntry(entry: unknown) {
+  if (!isObject(entry) || !isObject(entry.value) || !('value' in entry.value)) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    role: entry.role ?? entry.value.role,
+    value: entry.value.value,
+  };
+}
+
+function normalizeRecordMap(recordMap: ExtendedRecordMap): ExtendedRecordMap {
+  const normalizedRecordMap = { ...recordMap } as Record<string, unknown>;
+
+  for (const tableName of RECORD_MAP_TABLES) {
+    const table = normalizedRecordMap[tableName];
+
+    if (!isObject(table)) {
+      continue;
+    }
+
+    normalizedRecordMap[tableName] = Object.fromEntries(
+      Object.entries(table as RecordMapTable).map(([id, entry]) => [
+        id,
+        normalizeRecordMapEntry(entry),
+      ])
+    );
+  }
+
+  return normalizedRecordMap as unknown as ExtendedRecordMap;
+}
+
 export default function NotionPage({ recordMap }: NotionPageProps) {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const normalizedRecordMap = useMemo(() => normalizeRecordMap(recordMap), [recordMap]);
 
   useEffect(() => {
     // 初期値をユーザー設定から取得
@@ -41,7 +90,7 @@ export default function NotionPage({ recordMap }: NotionPageProps) {
   return (
     <div className="notion-page">
       <NotionRenderer 
-        recordMap={recordMap}
+        recordMap={normalizedRecordMap}
         fullPage={false}
         darkMode={isDarkMode} // ユーザー設定に応じて切替
         components={{


### PR DESCRIPTION
Notion本文データを描画前に正規化するように修正しました．

## 現状
<img width="1453" height="810" alt="image" src="https://github.com/user-attachments/assets/848426a7-6616-4953-9800-88be4a63bbef" />


## 修正後(ローカル)
<img width="1452" height="766" alt="image" src="https://github.com/user-attachments/assets/01a764c1-0860-4295-bec8-a506830b8038" />
